### PR TITLE
Remove call to reload! from Robe::Sash#rails_refresh!

### DIFF
--- a/lib/robe/sash.rb
+++ b/lib/robe/sash.rb
@@ -153,7 +153,8 @@ module Robe
     end
 
     def rails_refresh
-      reload!
+      ActionDispatch::Reloader.cleanup!
+      ActionDispatch::Reloader.prepare!
       Rails.application.eager_load!
     end
 


### PR DESCRIPTION
After calling `robe-rails-refresh` I had this error:

```
Request failed: /rails_refresh/. Please file an issue.
undefined method `reload!' for #<Robe::Sash:0x007fa4aac9abe8>
/Users/asok/.emacs.d/site-lisp/robe/lib/robe/sash.rb:156:in `rails_refresh'
/Users/asok/.emacs.d/site-lisp/robe/lib/robe/sash.rb:166:in `public_send'
/Users/asok/.emacs.d/site-lisp/robe/lib/robe/sash.rb:166:in `call'
/Users/asok/.emacs.d/site-lisp/robe/lib/robe/server.rb:37:in `block in start'
/Users/asok/.emacs.d/site-lisp/robe/lib/robe/server.rb:28:in `loop'
/Users/asok/.emacs.d/site-lisp/robe/lib/robe/server.rb:28:in `start'
/Users/asok/.emacs.d/site-lisp/robe/lib/robe.rb:18:in `block in start'
```

This fixes it.
