### PR TITLE
Do not assume prompt "=> "

### DIFF
--- a/robe.el
+++ b/robe.el
@@ -110,7 +110,7 @@ have constants, methods and arguments highlighted in color."
            started
            (comint-filter (process-filter proc))
            (tmp-filter (lambda (p s)
-                         (when (string-match-p "=> \"robe on\""
+                         (when (string-match-p "\"robe on\""
                                                (ansi-color-filter-apply s))
                            (setq started t))
                          (funcall comint-filter p s)))


### PR DESCRIPTION
For a rails 3.2.15 project using hirb 0.7.1, the console output is not prefixed by any prompt.  In pry, the prompt-prefix is user-configurable.

There should be no assumption that the prompt will be "=> " (or anything else) when starting robe.

Robe will not start when this hard-coded prompt assumption is not met; it will hang until the user types C-g. The "robe on" message will then be displayed in the console, but initialization will not complete (no "listening on..." message will be displayed), and the user will not have robe functionality.
