### PR TITLE
Remove ido load

### DIFF
--- a/robe.el
+++ b/robe.el
@@ -52,7 +52,6 @@
 (require 'json)
 (require 'url)
 (require 'url-http)
-(require 'ido)
 (require 'cl)
 (require 'thingatpt)
 (require 'eldoc)


### PR DESCRIPTION
Because ido-completing-read can be lazy-loaded, so we can load
ido lazy until using ido-completing-read.

And non-ido users can avoid loading ido by applying this fix.
