### PR TITLE
Fix killing the inf-ruby process buffer

### DIFF
--- a/robe.el
+++ b/robe.el
@@ -99,13 +99,14 @@ When called with a prefix argument, kills the current Ruby
 process, if any, and starts a new console for the current
 project."
   (interactive "P")
-  (let ((process (get-buffer-process inf-ruby-buffer)))
+  (let* ((ruby-buffer (get-buffer inf-ruby-buffer))
+         (process (get-buffer-process ruby-buffer)))
     (when (or force (not process))
       (setq robe-running nil)
       (when process
         (delete-process process))
-      (when (buffer-live-p inf-ruby-buffer)
-        (kill-buffer inf-ruby-buffer))
+      (when (buffer-live-p ruby-buffer)
+        (kill-buffer ruby-buffer))
       (if (or force
               (yes-or-no-p "No Ruby console running. Launch automatically?"))
           (let ((conf (current-window-configuration)))


### PR DESCRIPTION
Variable `inf-ruby-buffer` contains the name of the buffer where the
inf-ruby process is running. Hence `(buffer-live-p inf-ruby-buffer)`
always is `nil`.

This patch uses the buffer object with name `inf-ruby-buffer`.