### PR TITLE
Uninitialized constant error when triggering completion from within company-mode.

### DIFF
--- a/lib/robe/sash/doc_for.rb
+++ b/lib/robe/sash/doc_for.rb
@@ -1,5 +1,6 @@
 require 'pry'
 require 'ostruct'
+
 begin
   require 'pry-doc' if RUBY_ENGINE == "ruby"
 rescue LoadError

--- a/lib/robe/sash/doc_for.rb
+++ b/lib/robe/sash/doc_for.rb
@@ -1,4 +1,5 @@
 require 'pry'
+require 'ostruct'
 begin
   require 'pry-doc' if RUBY_ENGINE == "ruby"
 rescue LoadError


### PR DESCRIPTION
I have a rather complex Emacs setup (as most of us do :) )

I've got ``inf-ruby`` mode running in one window (with ``pry`` instead ``irb``), I've got flycheck running in my Ruby (+ ``robe``) buffer. I'm using ``company-mode`` for completion. When triggering completion for something simple, i.e.

```
"test".to_<trigger>
```

I'm getting this error:

```
E, [2015-04-17T01:23:03.705344 #36127] ERROR -- : uninitialized constant Robe::Sash::DocFor::OpenStruct
./elpa/robe-20150222.1644/lib/robe/sash/doc_for.rb:46:in `method_struct'
./elpa/robe-20150222.1644/lib/robe/sash/doc_for.rb:16:in `format'
./elpa/robe-20150222.1644/lib/robe/sash.rb:93:in `doc_for'
./elpa/robe-20150222.1644/lib/robe/sash.rb:176:in `public_send'
./elpa/robe-20150222.1644/lib/robe/sash.rb:176:in `call'
./elpa/robe-20150222.1644/lib/robe/server.rb:40:in `block in start'
./elpa/robe-20150222.1644/lib/robe/server.rb:28:in `loop'
./elpa/robe-20150222.1644/lib/robe/server.rb:28:in `start'
./elpa/robe-20150222.1644/lib/robe.rb:18:in `block in start'
```

Based on my research, I had found [this StackOverflow page](http://stackoverflow.com/questions/25601960/ruby-error-uninitialized-constant-openstruct-nameerror) page, which hinted that there might be a missing require in offending file (``lib/robe/sash/doc_for.rb``).

Applying this change, removes mentioned error for me and I couldn't imagine how it could break anything for others.