### PR TITLE
Explicitly hide "Contacting host" message when backend has responded

### DIFF
--- a/robe.el
+++ b/robe.el
@@ -154,6 +154,7 @@ project."
                                          (t "-")))
                                  args "/")))
          (response-buffer (robe-retrieve url)))
+    (message nil) ;; So "Contacting host" message is cleared
     (if response-buffer
         (prog1
             (with-current-buffer response-buffer


### PR DESCRIPTION
When there is no Robe completion for the word at point, the existing
code leaves the "Contacting host ..." message in the echo area, leading
the user to assume Emacs is still busy. This small patch explicitly
clears that message when the backend has responded.