### PR TITLE
Fix emacs warning: Making delay-mode-hooks buffer-local while locally…

### DIFF
--- a/robe.el
+++ b/robe.el
@@ -459,11 +459,11 @@ Only works with Rails, see e.g. `rinari-console'."
 (defun robe-doc-fontify-c-string (string)
   (with-temp-buffer
     (insert string)
-    (let ((delay-mode-hooks t))
-      (c-mode))
-    (run-hooks 'font-lock-mode-hook)
-    (font-lock-fontify-buffer)
-    (buffer-string)))
+    (delay-mode-hooks
+      (c-mode)
+      (run-hooks 'font-lock-mode-hook)
+      (font-lock-fontify-buffer)
+      (buffer-string))))
 
 (defun robe-toggle-source (button)
   (let* ((end (button-end button))


### PR DESCRIPTION
… let-bound!

Occurs on robe-doc requests that include C source, e.g. Pathname.new. Does
not appear harmful, but it's annoying. Verified that current form does in fact
suppress a test c-mode-hook.