### PR TITLE
Install the eldoc function even if robe-turn-on-eldoc is initially fa…

### DIFF
--- a/robe.el
+++ b/robe.el
@@ -682,8 +682,8 @@ The following commands are available:
 \\{robe-mode-map}"
   nil " robe" robe-mode-map
   (add-hook 'completion-at-point-functions 'robe-complete-at-point nil t)
+  (set (make-local-variable 'eldoc-documentation-function) 'robe-eldoc)
   (when robe-turn-on-eldoc
-    (set (make-local-variable 'eldoc-documentation-function) 'robe-eldoc)
     (turn-on-eldoc-mode)))
 
 (provide 'robe)


### PR DESCRIPTION
…lse.

While still leaving the minor mode off, of course.

Rationale:
1) It doesn't hurt anything
2) User might turn eldoc on later.
3) User might prefer to trigger eldoc with a keybinding rather than using the minor mode.

I'm in situation 3 :)    FYI, the recipe is:

(defun eldoc-show-forcibly ()
  (interactive)
  (require 'eldoc)
  (cl-letf (((symbol-function 'eldoc-display-message-p)
             (lambda (&rest ignored) t)))
    (eldoc-print-current-symbol-info)))
(global-set-key (kbd "M-?") 'eldoc-show-forcibly)

, works for elisp as well (the major use case)