### PR TITLE
use not deprecated variable but function to get inf-ruby-buffer

### DIFF
--- a/robe.el
+++ b/robe.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/dgutov/robe
 ;; Version: 0.7.9
 ;; Keywords: ruby convenience rails
-;; Package-Requires: ((inf-ruby "2.3.0"))
+;; Package-Requires: ((inf-ruby "2.5.0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -112,8 +112,7 @@ When called with a prefix argument, kills the current Ruby
 process, if any, and starts a new console for the current
 project."
   (interactive "P")
-  (let* ((ruby-buffer (and inf-ruby-buffer
-                           (get-buffer inf-ruby-buffer)))
+  (let* ((ruby-buffer (inf-ruby-buffer))
          (process (get-buffer-process ruby-buffer)))
     (when (or force (not process))
       (setq robe-running nil)


### PR DESCRIPTION
At present, inf-ruby provides a function to get `inf-ruby-buffer` as substitute for just variable.
It seems this function gets the buffer matches `current-buffer`.
So, it makes we are available robe.el under multiple projects.