### PR TITLE
Let Robe start in virtual environment

### DIFF
--- a/lib/robe.rb
+++ b/lib/robe.rb
@@ -5,10 +5,10 @@ module Robe
   class << self
     attr_accessor :server
 
-    def start(port = 0)
+    def start(host: "127.0.0.1", port: 0)
       return running_string if @server
 
-      @server = Server.new(Sash.new, port)
+      @server = Server.new(Sash.new, host, port)
 
       ['INT', 'TERM'].each do |signal|
         trap(signal) { stop }

--- a/lib/robe/server.rb
+++ b/lib/robe/server.rb
@@ -8,9 +8,9 @@ module Robe
   class Server
     attr_reader :running, :port
 
-    def initialize(handler, port)
+    def initialize(handler, host, port)
       @handler = handler
-      @server = TCPServer.new("127.0.0.1", port)
+      @server = TCPServer.new(host, port)
       @running = true
       @port = @server.addr[1]
     end


### PR DESCRIPTION
I'm developing using docker.
So, it requires that robe starts in docker container as virtual environment.
Therefore, robe has to receive a host option for starting server.

We'll be able to develop using robe under docker container from this patch and [docker-robe.el](https://github.com/aki2o/emacs-docker-robe).