### PR TITLE
tests: explicitly require robe

### DIFF
--- a/ert/robe-tests.el
+++ b/ert/robe-tests.el
@@ -1,4 +1,5 @@
 (require 'ert-x)
+(require 'robe)
 
 (ert-deftest signature-for-simple-args ()
   (should (string= (robe-signature '("C" t "foo" (("req" "a") ("req" "b"))))


### PR DESCRIPTION
This avoids having to add `-l robe` in the test command (if you're running it outside of `rake ert`).