### PR TITLE
Document webrick dependency in ruby 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ or
 
 * `pry` >= 0.10
 * `pry-doc` >= 0.6.0 (for stdlib docs on MRI; optional)
+* `webrick` >= 1.5.0 (for ruby >= 3.0.0; WEBrick was removed from the standard library in [3.0.0](https://rubyreferences.github.io/rubychanges/3.0.html#libraries-excluded-from-the-standard-library))
 
 Note that if your project is using `Bundler`, the dependencies have to be added to the `Gemfile`.
 


### PR DESCRIPTION
In ruby 3.0.0, [webrick has been removed from the standard library](https://rubyreferences.github.io/rubychanges/3.0.html#libraries-excluded-from-the-standard-library). This means that it must be added to your Gemfile in order to use robe in a ruby 3.0.0 project.

Once webrick is installed, everything seems to work well!