### PR TITLE
Ignore the '(eval)' string

### DIFF
--- a/lib/robe/sash/const_locations.rb
+++ b/lib/robe/sash/const_locations.rb
@@ -23,7 +23,7 @@ module Robe
             if (loc = m.source_location)
               path = loc[0]
 
-              next if path.start_with?('<internal:') # Kernel.instance_method(:warn).source_location[0], Ruby 3
+              next if path.start_with?(/<internal:|\(eval\)/) # Kernel.instance_method(:warn).source_location[0], Ruby 3
 
               locations[path] ||= 0
               locations[path] += 1


### PR DESCRIPTION
"Can't find the location when" occurs when dealing with dsl like sinatra. The reason is that the method defined in the class is returned as eval.

```rb
require 'sinatra/base'

class HomePage < Sinatra::Base
  enable :sessions
end
```

In this situation, debugging the methods variable in Sash::ConstLocations.all contained the following values.

```
#<Method: HomePage.sessions() (eval):1>`
```

The following error will occur if the string "eval" is included in the hash "path".

```
E, [2022-12-06T11:20:20.373658 #43738] ERROR -- : No such file or directory @ rb_sysopen - (eval)
```